### PR TITLE
Make sure TEXMFVAR is writable.

### DIFF
--- a/org.freedesktop.Sdk.Extension.texlive.yml
+++ b/org.freedesktop.Sdk.Extension.texlive.yml
@@ -50,8 +50,7 @@ modules:
   build-commands:
     - 7z x texlive2020.iso
     - chmod +x install-tl
-    - "echo \"I\nn\" | TEXLIVE_INSTALL_PREFIX=/usr/lib/sdk/texlive ./install-tl -portable"
-    - rm -rf /usr/lib/sdk/texlive/texmf-dist/doc
+    - ./install-tl -profile texlive.profile
 - name: perl # required for makeglossaries
   no-autogen: true
   config-opts:

--- a/texlive.profile
+++ b/texlive.profile
@@ -1,0 +1,30 @@
+# texlive.profile written on Sun Aug 23 13:30:43 2020 UTC
+# It will NOT be updated and reflects only the
+# installation profile at installation time.
+selected_scheme scheme-full
+TEXDIR /usr/lib/sdk/texlive
+TEXMFCONFIG $XDG_CONFIG_HOME/texmf-config
+TEXMFHOME $XDG_DATA_HOME/texmf
+TEXMFLOCAL /usr/lib/sdk/texlive/texmf-local
+TEXMFSYSCONFIG /usr/lib/sdk/texlive/texmf-config
+TEXMFSYSVAR /usr/lib/sdk/texlive/texmf-var
+TEXMFVAR $XDG_CACHE_HOME/texmf-var
+binary_x86_64-linux 1
+instopt_adjustpath 0
+instopt_adjustrepo 1
+instopt_letter 0
+instopt_portable 0
+instopt_write18_restricted 1
+tlpdbopt_autobackup 1
+tlpdbopt_backupdir tlpkg/backups
+tlpdbopt_create_formats 1
+tlpdbopt_desktop_integration 1
+tlpdbopt_file_assocs 1
+tlpdbopt_generate_updmap 0
+tlpdbopt_install_docfiles 0
+tlpdbopt_install_srcfiles 0
+tlpdbopt_post_code 1
+tlpdbopt_sys_bin /usr/local/bin
+tlpdbopt_sys_info /usr/local/share/info
+tlpdbopt_sys_man /usr/local/share/man
+tlpdbopt_w32_multi_user 1


### PR DESCRIPTION
This change sets TEXMFVAR, TEXMFCONFIG and TEXMFHOME to their respective
XDG directory names, which point to writable locations within Flatpak mounts.

Instead of the interactive installer, a TeXLive installer profile is added.
Other changes:

 - Installation isn't portable (otherwise the paths aren't adjustable, and it
   isn't needed anyway).
 - Documentation + Source files aren't installed (doc would before be installed
   and afterwards immediately removed).

Specifically this fixes this issue: https://tex.stackexchange.com/a/559683/90407