### PR TITLE
fix texlive target actually not building

### DIFF
--- a/org.freedesktop.Sdk.Extension.texlive.yml
+++ b/org.freedesktop.Sdk.Extension.texlive.yml
@@ -47,6 +47,8 @@ modules:
         url: http://mirror.ctan.org/systems/texlive/Images
         version-pattern: texlive(\d\d\d\d).iso
         url-template: http://mirror.ctan.org/systems/texlive/Images/texlive$version.iso
+    - type: file
+      path: texlive.profile
   build-commands:
     - 7z x texlive2020.iso
     - chmod +x install-tl


### PR DESCRIPTION
I'm sorry, my previous PR #29 introduced a bug where I forgot to list the `texlive.profile` in the source files, thus the installer actually never building.  I've introduced that bug after testing my draft and was too lazy to rebuild as this takes quite some ages.

Edit: My personal built ran and I ran a few tests, this one is fine.