### PR TITLE
Add python3-pygment

### DIFF
--- a/org.freedesktop.Sdk.Extension.texlive.yml
+++ b/org.freedesktop.Sdk.Extension.texlive.yml
@@ -122,6 +122,14 @@ modules:
         url: https://sourceforge.net/projects/biblatex/files/biblatex-3.19/biblatex-3.19.tds.tgz
         sha256: 7db64bdcdab7bbda00b6065ed5388ab0ff2967006ba07c6006b1701e9858537d
         dest-filename: biblatex.tds.tgz
+  - name : python3-pygments
+    buildsystem: simple
+    build-commands:
+      - pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pygments\"
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/d6/f7/4d461ddf9c2bcd6a4d7b2b139267ca32a69439387cc1f02a924ff8883825/Pygments-2.16.1.tar.gz
+        sha256: 1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29
   - name: ghostscript
     config-opts:
       - --disable-cups


### PR DESCRIPTION
Close #25

My laptop is not powerful  enough to test it but it should work.

This PR add python3-pygment as a dependency to enable the use of the popular Latex module [minted](https://www.ctan.org/pkg/minted). 