### PR TITLE
Revert "Delete *.pdf"

### DIFF
--- a/org.freedesktop.Sdk.Extension.texlive.yml
+++ b/org.freedesktop.Sdk.Extension.texlive.yml
@@ -14,8 +14,6 @@ build-options:
       prepend-path: /usr/lib/sdk/texlive/bin/aarch64-linux
     x86_64:
       prepend-path: /usr/lib/sdk/texlive/bin/x86_64-linux
-cleanup:
-  - '*.pdf'
 modules:
   - name: texlive-texmf
     buildsystem: simple


### PR DESCRIPTION
Reverts flathub/org.freedesktop.Sdk.Extension.texlive#180 as it breaks the beamer class (and potentially other classes relying on pdf files during the compilation)